### PR TITLE
feat: add CLI command

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,21 @@ Merge package.json using local, base, and remote
 * Follows SemVer
 * Uses best guess to resolve conflicts
 
+### CLI
+
+```
+npm install --global merge-package.json
+```
+
+Then just run `merge-package-json` in a directory with merge conflicts in
+`package.json`.  It will write the merged output back to `package.json`.
+
+### Node API
+
+```
+npm install --save merge-package.json
+```
+
 ```js
 const mergePackageJson = require('merge-package.json');
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "2.0.1",
   "description": "Merge package.json using local, base, and remote",
   "main": "src/index.js",
+  "bin": {
+    "merge-package-json": "src/cli.js"
+  },
   "scripts": {
     "test": "mocha test/**/*-test.js",
     "posttest": "npm run lint",

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,0 +1,12 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const { execSync } = require('child_process');
+const mergePackageJson = require('./index');
+
+const local = execSync('git show HEAD:package.json').toString('utf8');
+const baseCommit = execSync('git merge-base HEAD MERGE_HEAD').toString('utf8').trim();
+const base = execSync(`git show ${baseCommit}:package.json`).toString('utf8');
+const remote = execSync('git show MERGE_HEAD:package.json').toString('utf8');
+
+fs.writeFileSync('package.json', mergePackageJson(local, base, remote), 'utf8');


### PR DESCRIPTION
Thanks for this great package!

I added a simple CLI command, you just run `merge-package-json` in your project directory
after a merge failed with merge conflicts in `package.json`, and it writes
the merged output to `package.json`.  It uses `git show HEAD:package.json`, `git show MERGE_HEAD:package.json`, and also `git show` with the output of `git merge-base HEAD MERGE_HEAD` to get the input for your existing Node API.