### PR TITLE
remove bundledDependencies from processing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2302,7 +2302,8 @@
     "semver": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
+      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+      "dev": true
     },
     "set-blocking": {
       "version": "2.0.0",
@@ -2635,11 +2636,18 @@
       "dev": true
     },
     "three-way-merger": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/three-way-merger/-/three-way-merger-0.5.5.tgz",
-      "integrity": "sha512-zRmsTqSU3B3ObzM83ueb4jiJQhaF8YfL4K9SXUR+KuW7YvdLg8GdJElrQ5PU57QEiqLe2KKcR+YM2lvrDkLyyg==",
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/three-way-merger/-/three-way-merger-0.5.7.tgz",
+      "integrity": "sha512-aD2nvGowCgJxoH49Izou5uR4PLCuH2yiw6+BJPg0H7RCLzpLy/4J9onM9sPXetmsq/AVfZ8fEyf8lbGKxKPrcA==",
       "requires": {
-        "semver": "^5.4.1"
+        "semver": "^6.0.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.0.0.tgz",
+          "integrity": "sha512-0UewU+9rFapKFnlbirLi3byoOuhrSsli/z/ihNnvM24vgF+8sNBiI1LZPBSH9wJKUwaUbw+s3hToDLCXkrghrQ=="
+        }
       }
     },
     "through": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "rfc6902-ordered": "^3.1.1",
-    "three-way-merger": "^0.5.5"
+    "three-way-merger": "^0.5.7"
   },
   "devDependencies": {
     "chai": "^4.1.2",

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,6 @@ const dependencyKeys = [
   'dependencies',
   'devDependencies',
   'peerDependencies',
-  'bundledDependencies',
   'optionalDependencies'
 ];
 


### PR DESCRIPTION
@elwayman02 informed me I made a mistake treating bundledDependencies like the other dependencies. It is in fact an array and not an object with versions.

https://github.com/ember-cli/ember-cli-update/issues/539